### PR TITLE
Fix < loc > URLs generation for URLs with '&'

### DIFF
--- a/sitemap_generator/index.php
+++ b/sitemap_generator/index.php
@@ -107,7 +107,7 @@ function sitemap_add_url($url = '', $date = '', $freq = 'daily') {
 
     $filename = osc_base_path() . 'sitemap.xml';
     $xml  = '    <url>' . PHP_EOL;
-    $xml .= '        <loc>' . htmlentities($url, ENT_QUOTES, "UTF-8") . '</loc>' . PHP_EOL;
+    $xml .= '        <loc>' . htmlspecialchars($url, ENT_QUOTES, "UTF-8") . '</loc>' . PHP_EOL;
     $xml .= '        <lastmod>' . $date . '</lastmod>' . PHP_EOL;
     $xml .= '        <changefreq>' . $freq . '</changefreq>' . PHP_EOL;
     $xml .= '    </url>' . PHP_EOL;


### PR DESCRIPTION
To Convert special characters, especially the **&** found in OSClass search URLs, to HTML entities

taken from https://github.com/pawelantczak/php-sitemap-generator/blob/master/SitemapGenerator.php#L190 an excellent sitemap generator
